### PR TITLE
fixes for custom quizes

### DIFF
--- a/DAAJE/devserver/controllers/controller.js
+++ b/DAAJE/devserver/controllers/controller.js
@@ -1,5 +1,5 @@
 // controller functions for mongodb
-
+/* eslint-disable */
 // passport
 const passport = require("passport");
 const LocalStrategy = require("passport-local").Strategy;
@@ -53,6 +53,19 @@ async function findUserQuiz(id) {
 // Create a new quiz and embed
 exports.createQuiz = async(req, res) => {
     const id = req.params.id;
+    // format the quiz id(name) to be the same as the name with added underscores
+    if(!req.body.id || req.body.id === '') {
+        let nameString = req.body.name.split(' ');
+        let modifiedString = '';
+        for (let i of nameString) {
+            modifiedString += `${i}_`;
+        }
+        req.body.id = modifiedString.substring(0, modifiedString.length-1);
+    } else { req.body.id = undefined; } // setting to undefined allows the model to set the value to default
+    for(let i in req.body.questions) { // add id field starting from 1 to all questions in quiz
+        console.log(i);
+        req.body.questions[i].id = parseInt(i) + 1;
+    }
     const quizModel = await new Quiz(req.body);
 /*     const _user = await User.findById(id)
         .then(data => {
@@ -70,7 +83,7 @@ exports.createQuiz = async(req, res) => {
         { $push: {"created.quiz": quizModel} },
         { new: true, select: "created" },
     );
-    console.log(_user);
+    res.status(200);
 /*     (err, _data) => { 
         if(err) {
             return res.status(500).send(err)

--- a/DAAJE/devserver/models/quiz.model.js
+++ b/DAAJE/devserver/models/quiz.model.js
@@ -3,7 +3,10 @@ const mockQuiz = mongoose => {
       "mock_quiz",
       mongoose.Schema(
         {
-          id: String,
+          id: {
+            type: String,
+            default: "custom"
+          },
           img: String,
           name: String,
           questions: Array,

--- a/DAAJE/index.html
+++ b/DAAJE/index.html
@@ -8,7 +8,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <button type="button" onclick="findUser()">add custom quiz</button>
     <script type="module" src="/src/main.js"></script>
     <script>
       function findUser() {                                     //logged in uid required in request

--- a/DAAJE/src/router/index.js
+++ b/DAAJE/src/router/index.js
@@ -38,7 +38,7 @@ const routes = [
     path: '/quiz/:id',
     name: 'QuizView',
     props: (route) => ({ ...route.params, id: route.params.id }),
-    beforeEnter(to, from) {
+/*     beforeEnter(to, from) {
       const exists = quizes.value.find((quiz) => quiz.id === to.params.id);
       if (!exists) return {
           name: 'NotFound',
@@ -47,7 +47,7 @@ const routes = [
           query: to.query,
           hash: to.hash,
         };
-    },
+    }, */
     component: QuizView,
   },
   {

--- a/DAAJE/src/views/QuizView.vue
+++ b/DAAJE/src/views/QuizView.vue
@@ -23,8 +23,9 @@ const resultStore = useResultStore();
 // empty resultStore for new quiz
 resultStore.$reset()
 
-
-const result = await axios.get("http://localhost:8080/quiz_questions");
+const userid = localStorage.getItem("usertoken");
+const result = await axios.get(`http://localhost:8080/quiz_questions/${userid}`);
+console.log(result);
 const quizes = ref(result.data);
 
 const quizToShow = quizes.value.find((quiz) => quiz.id === paramsId);


### PR DESCRIPTION
- custom quizes have an id reflecting the provided name field, but with added underscores. this is neccesary for the vue router push and read of params id
- custom quiz questions are enumerated under the field "id" starting from 1 and up.
- quiz models have a default id name